### PR TITLE
chore: bump version to 1.0.0 (maintainer change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Stable releases are hosted on [JCenter](https://bintray.com/bintray/jcenter).
 <dependency>
   <groupId>khttp</groupId>
   <artifactId>khttp</artifactId>
-  <version>0.1.0</version>
+  <version>1.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>khttp</groupId>
     <artifactId>khttp</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>khttp</name>
     <description>A HTTP request library for Kotlin.</description>
     <url>https://github.com/jkcclemens/khttp</url>


### PR DESCRIPTION
This version bump is to signify a change in maintainers. @bbeaupain will be taking over khttp development and maintenance. This git commit is signed with my PGP key, and the 1.0.0 release on JCenter is also signed with that key.

Here's to khttp being actively maintained again!